### PR TITLE
Add additionalPrinterColumns to CRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `additionalPrinterColumns` to the CRD so that more information is shown when fetching it from the k8s API.
+
 ## [0.1.0] - 2022-01-23
 
 [Unreleased]: https://github.com/giantswarm/apiextensions-backup/compare/v0.1.0...HEAD

--- a/api/v1alpha1/etcd_backup_types.go
+++ b/api/v1alpha1/etcd_backup_types.go
@@ -11,6 +11,9 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:categories=common;giantswarm,scope=Cluster
 // +k8s:openapi-gen=true
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.status`
+// +kubebuilder:printcolumn:name="Started",type="date",JSONPath=".status.startedTimestamp"
+// +kubebuilder:printcolumn:name="Finished",type="date",JSONPath=".status.finishedTimestamp"
 
 type ETCDBackup struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/backup.giantswarm.io_etcdbackups.yaml
+++ b/config/crd/backup.giantswarm.io_etcdbackups.yaml
@@ -19,7 +19,17 @@ spec:
     singular: etcdbackup
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    - jsonPath: .status.startedTimestamp
+      name: Started
+      type: date
+    - jsonPath: .status.finishedTimestamp
+      name: Finished
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:


### PR DESCRIPTION
Add more information while issuing `kubectl get etcdbackups` so that it's easier to find failed backups.